### PR TITLE
Replaced FHDPosterUrl with LandscapeUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The ```tmdb_id``` column will be essential for using The Movie Database's APIs a
 
 #### *Poster Artwork*
 
-The ```hdposterurl``` column is used to create URLs for posters (media types ```Movies``` and ```Shows```). It must link to an image file with a 2:3 ratio and will be rendered on the Roku app as ```108x162 px```. The ```fhdposterurl``` column is used for landscape backdrops. It must link to an image file with a 16:9 ratio and is rendered as ```388x218 px``` for the movie details screen and ```185x104 px``` for the episode thumbnails. ***The ```fhdposterurl``` tag is being repurposed here, so it can be pulled in easily with the ```setFields()``` method.***
+The ```hdposterurl``` column is used to create URLs for portrait posters (media types ```Movies``` and ```Shows```). It must link to an image file with a 2:3 ratio and will be rendered on the Roku app as ```108x162 px```. The ```landscapeurl``` column is used for landscape backdrops. It must link to an image file with a 16:9 ratio and is rendered as ```388x218 px``` for the movie details screen and ```185x104 px``` for the episode thumbnails.
 
 The ```secondarytitle``` column is used for the year the movie was released as suggested by Roku's content metadata documentation.
 

--- a/backend/nasplay_server/schema.sql
+++ b/backend/nasplay_server/schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE content (
         "secondarytitle"        TEXT,
         "description"   TEXT,
         "hdposterurl"   TEXT,
-        "fhdposterurl"  TEXT,
+        "landscapeurl"  TEXT,
         "releasedate"   TEXT,
         "rating_id"     INTEGER,
         "episodenumber" INTEGER,
@@ -54,7 +54,7 @@ CREATE VIEW content_view AS
           , c.secondarytitle SecondaryTitle
           , c.description Description
           , c.hdposterurl HDPosterUrl
-          , c.fhdposterurl FHDPosterUrl
+          , c.landscapeurl LandscapeUrl
           , c.releasedate ReleaseDate
           , r.rating Rating
           , c.episodenumber EpisodeNumber

--- a/frontend/nasplay/components/EpisodeMarkupListItem.brs
+++ b/frontend/nasplay/components/EpisodeMarkupListItem.brs
@@ -6,7 +6,7 @@ end sub
 
 sub itemContentChanged()
     m.itemcontent = m.top.itemContent
-    m.poster.uri = m.itemcontent.FHDPosterUrl
+    m.poster.uri = m.itemcontent.LandscapeUrl
     m.title.text = m.itemcontent.Title
     m.description.text = m.itemcontent.Description
 end sub

--- a/frontend/nasplay/components/MainScene.brs
+++ b/frontend/nasplay/components/MainScene.brs
@@ -117,7 +117,6 @@ function GetContent(contentType = invalid)
                     Title: item.Title,
                     Description: item.Description,
                     HDPosterUrl: item.HDPosterUrl,
-                    FHDPosterUrl: item.FHDPosterUrl,
                     ContentType: item.ContentType,
                     ReleaseDate: item.ReleaseDate,
                     Rating: item.Rating,
@@ -135,6 +134,8 @@ function GetContent(contentType = invalid)
                 ' ID (uuid) maps to the built-in node id field
                 childNode.id = item.ID
                 ' Custom fields not in standard ContentNode schema
+                childNode.addField("LandscapeUrl", "string", false)
+                childNode.setField("LandscapeUrl", item.LandscapeUrl)
                 childNode.addField("TitleSeason", "string", false)
                 childNode.setField("TitleSeason", item.TitleSeason)
                 childNode.addField("SeriesID", "string", false)

--- a/frontend/nasplay/components/MovieDetailsPanel.brs
+++ b/frontend/nasplay/components/MovieDetailsPanel.brs
@@ -14,7 +14,7 @@ end sub
 
 sub UpdatePoster()
     m.posterNode = m.top.content
-    m.moviePoster.uri = m.posterNode.FHDPosterUrl
+    m.moviePoster.uri = m.posterNode.LandscapeUrl
     m.top.overhangTitle = m.posterNode.Title
     m.description.text = m.posterNode.Description
     info = ""

--- a/frontend/nasplay/manifest
+++ b/frontend/nasplay/manifest
@@ -1,7 +1,7 @@
 title=nasplay
 major_version=2
 minor_version=0
-build_version=0
+build_version=1
 
 mm_icon_focus_hd=pkg:/images/nasplay_290x218.png
 mm_icon_focus_fhd=pkg:/images/nasplay_540x405.png


### PR DESCRIPTION
FHDPosterUrl was intended to be used as lanscape images, but Roku uses FHDPosterUrl in place of HDPosterUrl if both exist on a 4K device.